### PR TITLE
Fix padding

### DIFF
--- a/src/components/TransitionExpand.vue
+++ b/src/components/TransitionExpand.vue
@@ -38,13 +38,15 @@ export default {
           // animation is triggered correctly.
           // eslint-disable-next-line no-unused-expressions
           getComputedStyle(element).height;
+          // eslint-disable-next-line no-param-reassign
           element.style.transition = '';
 
           requestAnimationFrame(() => {
-            // eslint-disable-next-line no-param-reassign
+            /* eslint-disable no-param-reassign */
             element.style.height = height;
             element.style.paddingTop = paddingTop;
             element.style.paddingBottom = paddingBottom;
+            /* eslint-enable */
           });
         },
         leave(element) {
@@ -59,10 +61,11 @@ export default {
           getComputedStyle(element).height;
 
           requestAnimationFrame(() => {
-            // eslint-disable-next-line no-param-reassign
+            /* eslint-disable no-param-reassign */
             element.style.height = 0;
             element.style.paddingTop = 0;
             element.style.paddingBottom = 0;
+            /* eslint-enable */
           });
         },
       },

--- a/src/components/TransitionExpand.vue
+++ b/src/components/TransitionExpand.vue
@@ -20,25 +20,31 @@ export default {
           element.style.position = `absolute`;
           element.style.visibility = `hidden`;
           element.style.height = `auto`;
+          element.style.transition = `none`;
           /* eslint-enable */
 
-          const { height } = getComputedStyle(element);
+          const { height, paddingTop, paddingBottom } = getComputedStyle(element);
 
           /* eslint-disable no-param-reassign */
           element.style.width = null;
           element.style.position = null;
           element.style.visibility = null;
           element.style.height = 0;
+          element.style.paddingTop = 0;
+          element.style.paddingBottom = 0;
           /* eslint-enable */
 
           // Force repaint to make sure the
           // animation is triggered correctly.
           // eslint-disable-next-line no-unused-expressions
           getComputedStyle(element).height;
+          element.style.transition = '';
 
           requestAnimationFrame(() => {
             // eslint-disable-next-line no-param-reassign
             element.style.height = height;
+            element.style.paddingTop = paddingTop;
+            element.style.paddingBottom = paddingBottom;
           });
         },
         leave(element) {
@@ -55,6 +61,8 @@ export default {
           requestAnimationFrame(() => {
             // eslint-disable-next-line no-param-reassign
             element.style.height = 0;
+            element.style.paddingTop = 0;
+            element.style.paddingBottom = 0;
           });
         },
       },
@@ -77,7 +85,7 @@ export default {
 <style>
 .expand-enter-active,
 .expand-leave-active {
-  transition: height 1s ease-in-out;
+  transition: height 1s ease-in-out, padding 1s ease-in-out;
   overflow: hidden;
 }
 


### PR DESCRIPTION
# Problem

Vue component code does not work with elements that have a CSS padding.

# Fix 

Add padding get and set functionality. In addition, the rendering of padding works differently and therefore the CSS transitions of the element must be removed before `getComputedStyle` is called. 

